### PR TITLE
Add user_id foreign key reference to Posts create table

### DIFF
--- a/loaddata.sql
+++ b/loaddata.sql
@@ -38,7 +38,8 @@ CREATE TABLE "Posts" (
   "publication_date" date,
   "image_url" varchar,
   "content" varchar,
-  "approved" bit
+  "approved" bit,
+  FOREIGN KEY(`user_id`) REFERENCES `Users`(`id`),
 );
 
 CREATE TABLE "Comments" (


### PR DESCRIPTION
In `loaddata.sql` the CREATE TABLE for Posts was missing a foreign key designation for the user_id FK. I added one. Dropping mic now.